### PR TITLE
Delete `docs/Manifest.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-*.jl.*.cov
-*.jl.cov
-*.jl.mem
-/Manifest.toml
-/docs/build/
-*~
-src/*~


### PR DESCRIPTION
In my experience, the `docs/Manifest.toml` file frequently causes trouble.