### PR TITLE
reduce latency of setting a stride array to zero via broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StrideArrays"
 uuid = "d1fa6d79-ef01-42a6-86c9-f7c551f8593b"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -217,7 +217,7 @@ end
 function sort_indices!(ar, R, C)
     any(i -> R[i-1] ≥ R[i], 2:length(R)) || return nothing
     li = ar.loopedindex; NN = length(li)
-    # all(n -> ((Xv[n+1]) % UInt) ≥ ((Xv[n]) % UInt), 1:NN-1) && return nothing    
+    # all(n -> ((Xv[n+1]) % UInt) ≥ ((Xv[n]) % UInt), 1:NN-1) && return nothing
     inds = LoopVectorization.getindices(ar); offsets = ar.ref.offsets;
     sp = rank_to_sortperm(R)
     # sp = sortperm(reinterpret(UInt,Xv), alg = Base.Sort.DEFAULT_STABLE)
@@ -302,7 +302,7 @@ end
     sp = sort_indices!(destmref, R, C)
     for n ∈ 1:N
         itersym = loopsyms[n]#isnothing(sp) ? n : sp[n]]
-        # _s = 
+        # _s =
         Sₙ =_extract(S.parameters[n])# (_s === nothing ? -1 : _s)::Int
         if Sₙ === nothing
             Sₙsym = gensym(:Sₙ); Rₙsym = gensym(:Rₙ)
@@ -372,6 +372,11 @@ end
 #     q
 #     # ls
 # end
+
+@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{ArrayStyle, Nothing, typeof(identity), Tuple{T}}) where {S,D,T,N,C,B,R,X,O,ArrayStyle}
+    fill!(dest, first(bc.args))
+end
+
 @inline function Base.Broadcast.materialize(bc::Base.Broadcast.Broadcasted{S}) where {S <: AbstractStrideStyle}
     ElType = Base.Broadcast.combine_eltypes(bc.f, bc.args)
     Base.Broadcast.materialize!(similar(bc, ElType), bc)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -373,7 +373,7 @@ end
 #     # ls
 # end
 
-@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{T2}}) where {S,D,T<:NativeTypes,N,C,B,R,X,O,T2<:Number}
+@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{T2}}) where {S,D,T,N,C,B,R,X,O,T2<:Number}
     fill!(dest, first(bc.args))
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -373,7 +373,7 @@ end
 #     # ls
 # end
 
-@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{T2}}) where {S,D,T,N,C,B,R,X,O,T2<:Number}
+@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{T2}}) where {S,D,T,N,C,B,R,X,O,T2<:Number}
     fill!(dest, first(bc.args))
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -373,7 +373,7 @@ end
 #     # ls
 # end
 
-@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{ArrayStyle, Nothing, typeof(identity), Tuple{T}}) where {S,D,T,N,C,B,R,X,O,ArrayStyle}
+@inline function Base.Broadcast.materialize!(dest::AbstractStrideArray{S,D,T,N,C,B,R,X,O}, bc::Base.Broadcast.Broadcasted{DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{T2}}) where {S,D,T<:NativeTypes,N,C,B,R,X,O,T2<:Number}
     fill!(dest, first(bc.args))
 end
 

--- a/test/broadcast_tests.jl
+++ b/test/broadcast_tests.jl
@@ -12,6 +12,8 @@ using StrideArrays, Test
     Da = @. exp(Aa) + ba * log(ca');
 
     @test D ≈ Da
+    A .= zero(eltype(A))
+    @test all(==(0), A)
     # end
 end
 


### PR DESCRIPTION
On `master`:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add(["BenchmarkTools", "StrideArrays"]); Pkg.develop("StrideArrays")

julia> using BenchmarkTools, StrideArrays

julia> f_fill!(x) = fill!(x, zero(eltype(x)))

julia> f_broadcast!(x) = x .= zero(eltype(x))

julia> function f_loop!(x)
           @simd for i in eachindex(x)
               @inbounds x[i] = zero(eltype(x))
           end
           x
       end

julia> f_ccall!(x) = @ccall memset(pointer(x)::Ptr{Cvoid}, 0::Cint, (length(x)*sizeof(eltype(x)))::Csize_t)::Ptr{Cvoid}

julia> x_array = zeros(4, 4, 4, 250);

julia> x_stride = StrideArray(x_array);

julia> x_ptr = PtrArray(pointer(x_array), size(x_array));

julia> x_ptr_static = PtrArray(pointer(x_array), map(StaticInt, size(x_array)));

julia> for x in [x_array, x_stride, x_ptr, x_ptr_static]
           println(typeof(x))
           display(@benchmark f_fill!($x))
           display(@benchmark f_broadcast!($x))
           display(@benchmark f_loop!($x))
           display(@benchmark f_ccall!($x))
       end

Array{Float64, 4}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.472 μs (0.00% GC)
  median time:      1.571 μs (0.00% GC)
  mean time:        1.660 μs (0.00% GC)
  maximum time:     5.080 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.458 μs (0.00% GC)
  median time:      1.506 μs (0.00% GC)
  mean time:        1.592 μs (0.00% GC)
  maximum time:     6.045 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.459 μs (0.00% GC)
  median time:      1.496 μs (0.00% GC)
  mean time:        1.565 μs (0.00% GC)
  maximum time:     5.170 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.658 μs (0.00% GC)
  median time:      1.826 μs (0.00% GC)
  mean time:        1.966 μs (0.00% GC)
  maximum time:     7.064 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
StrideArray{NTuple{4, Int64}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, Int64, Int64, Int64}, NTuple{4, StaticInt{1}}, Array{Float64, 4}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.459 μs (0.00% GC)
  median time:      1.514 μs (0.00% GC)
  mean time:        1.616 μs (0.00% GC)
  maximum time:     6.029 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     3.425 μs (0.00% GC)
  median time:      3.468 μs (0.00% GC)
  mean time:        3.628 μs (0.00% GC)
  maximum time:     10.475 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     8
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.495 μs (0.00% GC)
  median time:      1.582 μs (0.00% GC)
  mean time:        1.645 μs (0.00% GC)
  maximum time:     4.689 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.586 μs (0.00% GC)
  median time:      1.749 μs (0.00% GC)
  mean time:        1.840 μs (0.00% GC)
  maximum time:     6.777 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
PtrArray{NTuple{4, Int64}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, Int64, Int64, Int64}, NTuple{4, StaticInt{1}}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.511 μs (0.00% GC)
  median time:      1.585 μs (0.00% GC)
  mean time:        1.641 μs (0.00% GC)
  maximum time:     4.871 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     3.254 μs (0.00% GC)
  median time:      3.359 μs (0.00% GC)
  mean time:        3.513 μs (0.00% GC)
  maximum time:     11.556 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     8
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.521 μs (0.00% GC)
  median time:      1.617 μs (0.00% GC)
  mean time:        1.695 μs (0.00% GC)
  maximum time:     7.381 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.657 μs (0.00% GC)
  median time:      1.764 μs (0.00% GC)
  mean time:        1.870 μs (0.00% GC)
  maximum time:     6.700 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
PtrArray{Tuple{StaticInt{4}, StaticInt{4}, StaticInt{4}, StaticInt{250}}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, StaticInt{32}, StaticInt{128}, StaticInt{512}}, NTuple{4, StaticInt{1}}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.496 μs (0.00% GC)
  median time:      1.574 μs (0.00% GC)
  mean time:        1.644 μs (0.00% GC)
  maximum time:     11.825 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.489 μs (0.00% GC)
  median time:      1.564 μs (0.00% GC)
  mean time:        1.623 μs (0.00% GC)
  maximum time:     4.741 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.487 μs (0.00% GC)
  median time:      1.601 μs (0.00% GC)
  mean time:        1.685 μs (0.00% GC)
  maximum time:     6.435 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.527 μs (0.00% GC)
  median time:      1.649 μs (0.00% GC)
  mean time:        1.721 μs (0.00% GC)
  maximum time:     5.719 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
```

In the branch of this PR:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add(["BenchmarkTools", "StrideArrays"]); Pkg.develop("StrideArrays")

julia> using BenchmarkTools, StrideArrays

julia> f_fill!(x) = fill!(x, zero(eltype(x)))

julia> f_broadcast!(x) = x .= zero(eltype(x))

julia> function f_loop!(x)
           @simd for i in eachindex(x)
               @inbounds x[i] = zero(eltype(x))
           end
           x
       end

julia> f_ccall!(x) = @ccall memset(pointer(x)::Ptr{Cvoid}, 0::Cint, (length(x)*sizeof(eltype(x)))::Csize_t)::Ptr{Cvoid}

julia> x_array = zeros(4, 4, 4, 250);

julia> x_stride = StrideArray(x_array);

julia> x_ptr = PtrArray(pointer(x_array), size(x_array));

julia> x_ptr_static = PtrArray(pointer(x_array), map(StaticInt, size(x_array)));

julia> for x in [x_array, x_stride, x_ptr, x_ptr_static]
           println(typeof(x))
           display(@benchmark f_fill!($x))
           display(@benchmark f_broadcast!($x))
           display(@benchmark f_loop!($x))
           display(@benchmark f_ccall!($x))
       end

Array{Float64, 4}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.404 μs (0.00% GC)
  median time:      1.510 μs (0.00% GC)
  mean time:        1.641 μs (0.00% GC)
  maximum time:     7.734 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.382 μs (0.00% GC)
  median time:      1.484 μs (0.00% GC)
  mean time:        1.563 μs (0.00% GC)
  maximum time:     5.027 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.377 μs (0.00% GC)
  median time:      1.491 μs (0.00% GC)
  mean time:        1.555 μs (0.00% GC)
  maximum time:     7.573 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.565 μs (0.00% GC)
  median time:      1.791 μs (0.00% GC)
  mean time:        1.889 μs (0.00% GC)
  maximum time:     6.595 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
StrideArray{NTuple{4, Int64}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, Int64, Int64, Int64}, NTuple{4, StaticInt{1}}, Array{Float64, 4}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.402 μs (0.00% GC)
  median time:      1.505 μs (0.00% GC)
  mean time:        1.592 μs (0.00% GC)
  maximum time:     5.289 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.393 μs (0.00% GC)
  median time:      1.482 μs (0.00% GC)
  mean time:        1.538 μs (0.00% GC)
  maximum time:     6.196 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.386 μs (0.00% GC)
  median time:      1.511 μs (0.00% GC)
  mean time:        1.591 μs (0.00% GC)
  maximum time:     5.934 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.645 μs (0.00% GC)
  median time:      1.717 μs (0.00% GC)
  mean time:        1.799 μs (0.00% GC)
  maximum time:     6.741 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
PtrArray{NTuple{4, Int64}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, Int64, Int64, Int64}, NTuple{4, StaticInt{1}}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.395 μs (0.00% GC)
  median time:      1.467 μs (0.00% GC)
  mean time:        1.524 μs (0.00% GC)
  maximum time:     4.717 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.407 μs (0.00% GC)
  median time:      1.506 μs (0.00% GC)
  mean time:        1.603 μs (0.00% GC)
  maximum time:     6.948 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.417 μs (0.00% GC)
  median time:      1.509 μs (0.00% GC)
  mean time:        1.595 μs (0.00% GC)
  maximum time:     5.777 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.560 μs (0.00% GC)
  median time:      1.722 μs (0.00% GC)
  mean time:        1.822 μs (0.00% GC)
  maximum time:     6.598 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
PtrArray{Tuple{StaticInt{4}, StaticInt{4}, StaticInt{4}, StaticInt{250}}, (true, true, true, true), Float64, 4, 1, 0, (1, 2, 3, 4), Tuple{StaticInt{8}, StaticInt{32}, StaticInt{128}, StaticInt{512}}, NTuple{4, StaticInt{1}}}
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.359 μs (0.00% GC)
  median time:      1.476 μs (0.00% GC)
  mean time:        1.569 μs (0.00% GC)
  maximum time:     5.723 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.385 μs (0.00% GC)
  median time:      1.482 μs (0.00% GC)
  mean time:        1.598 μs (0.00% GC)
  maximum time:     7.075 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.372 μs (0.00% GC)
  median time:      1.468 μs (0.00% GC)
  mean time:        1.554 μs (0.00% GC)
  maximum time:     5.416 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.498 μs (0.00% GC)
  median time:      1.622 μs (0.00% GC)
  mean time:        1.703 μs (0.00% GC)
  maximum time:     5.508 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10
```

Additionally, the latency of 
```bash
julia -e '@time using StrideArrays; x_array = zeros(4, 4, 4, 250); x_stride = StrideArray(x_array); @time x_stride .= zero(eltype(x_stride))'
```
went down from 
```
  1.423262 seconds (3.85 M allocations: 227.937 MiB, 2.80% gc time, 2.01% compilation time)
  8.398219 seconds (13.54 M allocations: 779.841 MiB, 3.00% gc time, 0.09% compilation time)
```
to
```
  1.431065 seconds (3.85 M allocations: 228.063 MiB, 2.82% gc time, 2.02% compilation time)
  0.047297 seconds (115.75 k allocations: 7.239 MiB, 99.46% compilation time)
```
in this PR. Since setting an array to zero is a relatively common operation, this might be worth the effort of having an additional method, I think. At least it saves us quite some latency in Trixi.jl.